### PR TITLE
Fix Repo Assist auth and lock hash

### DIFF
--- a/.github/workflows/repo-assist.lock.yml
+++ b/.github/workflows/repo-assist.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"9c06f80eb7d3faf8028497408cbbc66054de120e7279ec90879e8e183445200c","body_hash":"cdde39d1b479755a2293a3c7fc300b0c1e886a21d6034dd9fc6c7c392954e0fe","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"c375654d430efd3c4e3b71db25969592a3da9489fd7cf5164bd1528092ecc0b8","body_hash":"cdde39d1b479755a2293a3c7fc300b0c1e886a21d6034dd9fc6c7c392954e0fe","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _
 #   / _ \                 | | (_)
@@ -94,6 +94,8 @@ on:
     - cron: "29 */12 * * *"
   # steps: # Steps injected into pre-activation job
   # - id: check
+  # env:
+  # GH_TOKEN: ${{ github.token }}
   # run: |
   # MAX_OPEN_PRS=8
   # if [[ "$GITHUB_EVENT_NAME" != "schedule" ]]; then exit 0; fi
@@ -1869,6 +1871,8 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_command_position.cjs');
             await main();
       - id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           MAX_OPEN_PRS=8
           if [[ "$GITHUB_EVENT_NAME" != "schedule" ]]; then exit 0; fi

--- a/.github/workflows/repo-assist.md
+++ b/.github/workflows/repo-assist.md
@@ -31,6 +31,8 @@ on:
     pull-requests: read
   steps:
     - id: check
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         MAX_OPEN_PRS=8
         if [[ "$GITHUB_EVENT_NAME" != "schedule" ]]; then exit 0; fi


### PR DESCRIPTION
## Summary
- add `GH_TOKEN: ${{ github.token }}` to the scheduled Repo Assist pre-activation PR-count check
- update the generated lock workflow metadata and pre-activation job env so scheduled/manual runs can pass the lock-file validation and authenticate `gh pr list`

## Failures addressed
- scheduled run `26924512737`: `pre_activation` failed at `gh pr list` without `GH_TOKEN`
- manual run `26944135727` / job `79492773523`: `activation` failed because the lock file metadata hash was stale (`main` recomputes `2720aefd...`, while the lock had `9c06f80...`)

## Validation
- YAML parse of `.github/workflows/repo-assist.lock.yml`
- `git diff --check`
- `GH_TOKEN=$(gh auth token) gh pr list --repo popey/halloy-snap --state open --search 'in:title "[repo-assist]"' --json number --jq 'length'`
- `gh aw hash-frontmatter .github/workflows/repo-assist.md` matches the updated lock metadata

Note: `gh aw compile repo-assist` currently fails before emission on the pre-existing `model: gpt-5-mini` frontmatter field (`Unknown property: model`). This PR keeps the change minimal and updates the generated lock file directly, matching the fix used in related repos.