### PR TITLE
Update Halloy to 2026.7.2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: halloy
-version: '2026.7.1'
+version: '2026.7.2'
 summary: IRC application written in Rust
 description: |
   Halloy is an open-source IRC client written in Rust, with the Iced


### PR DESCRIPTION
## Summary
- update Halloy from 2026.7.1 to 2026.7.2

## Validation
- `git diff --check`
- `snapcraft expand-extensions`
- downloaded upstream tag tarball for 2026.7.2


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the `halloy` snap version in `snap/snapcraft.yaml` from 2026.7.1 to 2026.7.2 to ship the latest upstream release.

<sup>Written for commit cda34894d28b43831ca882a904f3ebcd75c45d1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/popey/halloy-snap/pull/21?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

