### PR TITLE
test: add packaging check script

### DIFF
--- a/scripts/check-packaging.sh
+++ b/scripts/check-packaging.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  :
+else
+  ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+SNAP_LOCAL="$ROOT_DIR/snap/local"
+SNAPCRAFT_YAML="$ROOT_DIR/snap/snapcraft.yaml"
+
+failed=0
+
+if [ ! -d "$SNAP_LOCAL" ]; then
+  echo "ERROR: snap/local directory not found" >&2
+  failed=1
+fi
+
+if [ ! -f "$SNAPCRAFT_YAML" ]; then
+  echo "ERROR: snap/snapcraft.yaml not found" >&2
+  failed=1
+fi
+
+if [ "$failed" -ne 0 ]; then
+  exit 1
+fi
+
+mapfile -t commands < <(
+  awk '
+    /^[[:space:]]*command:[[:space:]]*/ {
+      sub(/^[[:space:]]*command:[[:space:]]*/, "")
+      gsub(/^["'\'']|["'\'']$/, "")
+      print
+    }
+  ' "$SNAPCRAFT_YAML"
+)
+
+if [ "${#commands[@]}" -eq 0 ]; then
+  echo "ERROR: no app command entries found in snap/snapcraft.yaml" >&2
+  exit 1
+fi
+
+for command in "${commands[@]}"; do
+  launcher="${command##* }"
+
+  if [[ "$launcher" = /* ]]; then
+    echo "Skipping absolute command path: $launcher"
+    continue
+  fi
+
+  launcher_path="$SNAP_LOCAL/$launcher"
+
+  if [ ! -f "$launcher_path" ]; then
+    echo "ERROR: launcher not found: $launcher_path" >&2
+    failed=1
+    continue
+  fi
+
+  if [ ! -x "$launcher_path" ]; then
+    echo "ERROR: launcher is not executable: $launcher_path" >&2
+    failed=1
+    continue
+  fi
+
+  echo "OK: $launcher is present and executable"
+done
+
+if [ "$failed" -ne 0 ]; then
+  exit 1
+fi
+
+echo "Packaging checks passed"


### PR DESCRIPTION
Adds a single maintained packaging check script that verifies snap/local exists, reads app command entries from snap/snapcraft.yaml, and checks relative launcher paths exist and are executable under snap/local.\n\nThis supersedes the duplicate Repo Assist packaging-check drafts: #33, #34, #37, #39, #40, and #41.\n\nAddresses #32.\n\nTested locally:\n\n```\nscripts/check-packaging.sh\n```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a packaging check script to validate Snap app launchers defined in snap/snapcraft.yaml. Replaces the previous draft scripts and addresses #32.

- **New Features**
  - Verifies presence of snap/local and snap/snapcraft.yaml.
  - Parses app command entries and checks each relative launcher exists under snap/local and is executable.
  - Skips absolute paths and exits non-zero on any failure.

<sup>Written for commit 11b62550bbe10979bdad6c6d5a34f6cbf0eceebf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/popey/halloy-snap/pull/45?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

