### PR TITLE
chore: add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Rust/Cargo
+/target/
+
+# Cargo registry and git database
+/.cargo/git/
+/.cargo/registry/
+
+# Snapcraft output
+/*.snap
+/.snap/
+/prime/
+/stage/
+/parts/
+
+# Editor and OS files
+*~
+.DS_Store
+.vscode/


### PR DESCRIPTION
Adds a small maintained .gitignore for Rust/Cargo output, local Cargo cache directories, snapcraft build artifacts, and common editor/OS files.\n\nSupersedes Repo Assist draft PR #42.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a .gitignore to exclude Rust/Cargo targets, local Cargo registry/git caches, Snapcraft build artifacts, and editor/OS files. Keeps build outputs and local state out of the repo to prevent accidental commits.

<sup>Written for commit 76038fb30d01e1bad62d6fe1f1ee5ab63df87ee4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/popey/halloy-snap/pull/46?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

